### PR TITLE
Throw informative exception on API error

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+
 part 'core.g.dart';
 
 @JsonSerializable()

--- a/lib/src/directions.dart
+++ b/lib/src/directions.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -236,7 +235,7 @@ class GoogleMapsDirections extends GoogleWebService {
   }
 
   DirectionsResponse _decode(Response res) =>
-      DirectionsResponse.fromJson(json.decode(res.body));
+      DirectionsResponse.fromJson(checkStatusAndDecode(res.body));
 }
 
 @JsonSerializable()

--- a/lib/src/distance.dart
+++ b/lib/src/distance.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -235,7 +234,7 @@ class GoogleDistanceMatrix extends GoogleWebService {
   }
 
   DistanceResponse _decode(Response res) =>
-      DistanceResponse.fromJson(json.decode(res.body));
+      DistanceResponse.fromJson(checkStatusAndDecode(res.body));
 }
 
 @JsonSerializable()

--- a/lib/src/geocoding.dart
+++ b/lib/src/geocoding.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -146,7 +145,7 @@ class GoogleMapsGeocoding extends GoogleWebService {
   }
 
   GeocodingResponse _decode(Response res) =>
-      GeocodingResponse.fromJson(json.decode(res.body));
+      GeocodingResponse.fromJson(checkStatusAndDecode(res.body));
 }
 
 @JsonSerializable()

--- a/lib/src/geolocation.dart
+++ b/lib/src/geolocation.dart
@@ -118,7 +118,7 @@ class GoogleMapsGeolocation extends GoogleWebService {
   }
 
   GeolocationResponse _decode(Response res) {
-    return GeolocationResponse.fromJson(json.decode(res.body));
+    return GeolocationResponse.fromJson(checkStatusAndDecode(res.body));
   }
 }
 

--- a/lib/src/places.dart
+++ b/lib/src/places.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -521,13 +520,13 @@ class GoogleMapsPlaces extends GoogleWebService {
   }
 
   PlacesSearchResponse _decodeSearchResponse(Response res) =>
-      PlacesSearchResponse.fromJson(json.decode(res.body));
+      PlacesSearchResponse.fromJson(checkStatusAndDecode(res.body));
 
   PlacesDetailsResponse _decodeDetailsResponse(Response res) =>
-      PlacesDetailsResponse.fromJson(json.decode(res.body));
+      PlacesDetailsResponse.fromJson(checkStatusAndDecode(res.body));
 
   PlacesAutocompleteResponse _decodeAutocompleteResponse(Response res) =>
-      PlacesAutocompleteResponse.fromJson(json.decode(res.body));
+      PlacesAutocompleteResponse.fromJson(checkStatusAndDecode(res.body));
 }
 
 @JsonSerializable()

--- a/lib/src/timezone.dart
+++ b/lib/src/timezone.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -66,7 +65,7 @@ class GoogleMapsTimezone extends GoogleWebService {
   }
 
   TimezoneResponse _decode(Response res) =>
-      TimezoneResponse.fromJson(json.decode(res.body));
+      TimezoneResponse.fromJson(checkStatusAndDecode(res.body));
 }
 
 @JsonSerializable(fieldRename: FieldRename.none)

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,7 @@
 library flutter_google_maps_webservices.utils;
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:http/http.dart';
 import 'package:meta/meta.dart';
@@ -98,4 +99,15 @@ DateTime dayTimeToDateTime(int day, String time) {
   final minute = int.parse(time.substring(2));
 
   return DateTime.utc(now.year, now.month, computedWeekday, hour, minute);
+}
+
+Map<String, dynamic> checkStatusAndDecode(String jsonBody) {
+  final jsonMap = json.decode(jsonBody);
+  if (jsonMap['errorMessage'] != null ||
+      jsonMap['status'] != null && jsonMap['status'] != 'OK') {
+    throw Exception('Google Maps WebServices API error: '
+        '${jsonMap['status'] ?? 'unknown status'} : '
+        '${jsonMap['errorMessage'] ?? 'no error message'}');
+  }
+  return jsonMap;
 }


### PR DESCRIPTION
`flutter_google_maps_webservices` does not check for errors in the responses from Google's API servers. This change throws an informative error, so the user knows exactly what's wrong (currently you get a `type 'Null' is not a subtype of...` error if the response JSON contains an error message, and not the expected fields...).

